### PR TITLE
Example to connect RPI Pico W to a custom wifi network

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.13)
+
+set(PROGRAM_NAME pico_wifi_ap_example)
+
+#set the script to resolve fsdata
+set(MAKE_FS_DATA_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/external/makefsdata)
+
+#if not exist, download from github. NOTE: needed internet connection
+if (NOT EXISTS ${MAKE_FS_DATA_SCRIPT})
+        file(DOWNLOAD
+                https://raw.githubusercontent.com/lwip-tcpip/lwip/e799c266facc3c70190676eccad49d6c2db2caac/src/apps/http/makefsdata/makefsdata
+                ${MAKE_FS_DATA_SCRIPT}
+                )
+endif()
+message("Running makefsdata script")
+
+#run the script to create the fsdata file
+execute_process(COMMAND
+        perl ${MAKE_FS_DATA_SCRIPT}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
+        ECHO_OUTPUT_VARIABLE
+        ECHO_ERROR_VARIABLE
+        )
+
+set(CMAKE_CXX_STANDARD 17)
+
+# Pull in Raspberry Pi Pico SDK (must be before project)
+include(pico_sdk_import.cmake)
+
+project(${PROGRAM_NAME}) 
+
+# Initialise the Raspberry Pi Pico SDK
+pico_sdk_init()
+
+add_subdirectory(WifiScanner)
+add_subdirectory(WebHandlers)
+
+add_executable(${PROGRAM_NAME}
+    main.cpp
+)
+
+# Modify the below lines to enable/disable output over UART/USB
+pico_enable_stdio_uart(${PROGRAM_NAME} 0)
+pico_enable_stdio_usb(${PROGRAM_NAME} 1)
+
+#set the RPI Pico SSID and password for AP mode
+set(WIFI_SSID "Pico_W" CACHE INTERNAL "WiFi SSID")
+set(WIFI_PASSWORD "12345678" CACHE INTERNAL "WiFi password")
+
+target_compile_definitions(${PROGRAM_NAME} PRIVATE
+        WIFI_SSID=\"${WIFI_SSID}\"
+        WIFI_PASSWORD=\"${WIFI_PASSWORD}\"
+        )
+
+target_include_directories(${PROGRAM_NAME} PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}
+  ${CMAKE_CURRENT_LIST_DIR}/common
+)
+
+target_link_libraries(${PROGRAM_NAME}
+    wifi_scanner
+    web_handlers
+    pico_stdlib
+    pico_cyw43_arch_lwip_poll
+    pico_lwip_http
+)
+
+pico_add_extra_outputs(${PROGRAM_NAME})

--- a/WebHandlers/CGI.cpp
+++ b/WebHandlers/CGI.cpp
@@ -1,0 +1,73 @@
+#include "CGI.h"
+
+std::vector<std::string> GetWiFiNetworks()
+{
+    return wifi_networks;
+}
+
+char* UrlDecode(const char* src) 
+{
+    size_t src_len = strlen(src);
+    char* decoded = (char*)malloc(src_len + 1);
+    size_t decoded_len = 0;
+
+    for (size_t i = 0; i < src_len; i++) 
+    {
+        if (src[i] == '%' && i + 2 < src_len) 
+        {
+            int hex_val;
+            sscanf(src + i + 1, "%2x", &hex_val);
+            decoded[decoded_len++] = hex_val;
+            i += 2;
+        } 
+        else if (src[i] == '+') 
+        {
+            decoded[decoded_len++] = ' ';
+        } 
+        else 
+        {
+            decoded[decoded_len++] = src[i];
+        }
+    }
+
+    decoded[decoded_len] = '\0';
+    return decoded;
+}
+
+void ScanWiFi() 
+{
+    wifi_networks.clear();
+    WiFiScanner wifi_scanner;
+    auto networks = wifi_scanner.ScanNetworks();
+    for(const auto & network : networks)
+    {
+        wifi_networks.push_back(network.ssid);
+    }
+}
+
+const char* ScanWiFiCGIHandler(int iIndex, int iNumParams, char *pcParam[], char *pcValue[]) 
+{
+    if(operation_in_progress)
+    {
+        printf("Operation in progress\n");
+        return "/index.shtml";;
+    }
+    
+    operation_in_progress = true;
+    ScanWiFi();
+    
+    operation_in_progress = false;
+    return "/index.shtml";
+}
+
+void CGIInit(const char* (*ConnectCallback)(int, int, char*[], char*[]))
+{
+    // CGI handlers array
+    static const tCGI kCGIHandlers[] = 
+    {
+        {"/connect", ConnectCallback},
+        {"/scan_wifi", ScanWiFiCGIHandler},
+    };
+    
+    http_set_cgi_handlers(kCGIHandlers, LWIP_ARRAYSIZE(kCGIHandlers));
+}

--- a/WebHandlers/CGI.h
+++ b/WebHandlers/CGI.h
@@ -1,0 +1,53 @@
+#ifndef WEB_HANDLERS_CGI_H
+#define WEB_HANDLERS_CGI_H
+
+/**
+ * @file CGI.h
+ * @brief Common Gateway Interface, used to handle HTTP requests sent by the client
+**/
+
+#include "lwip/apps/httpd.h"
+#include <stdio.h>
+#include <vector>
+
+#include "WiFiScanner.h"
+
+static std::vector<std::string> wifi_networks;
+
+static bool operation_in_progress = false;
+
+/**
+ * @brief Get the list of available WiFi networks
+ * @return The list of available WiFi networks
+*/
+std::vector<std::string> GetWiFiNetworks();
+
+/**
+ * @brief Decode a URL-encoded string
+ * @param src The URL-encoded string
+ * @return The decoded string
+*/
+char* UrlDecode(const char* src);
+
+/**
+ * @brief Scan for available WiFi networks
+*/
+void ScanWiFi();
+
+/**
+ * @brief Handle the WiFi scan request
+ * @param iIndex The index of the CGI handler
+ * @param iNumParams The number of parameters
+ * @param pcParam The parameter names
+ * @param pcValue The parameter values
+ * @return The page to redirect to
+*/
+const char* ScanWiFiCGIHandler(int iIndex, int iNumParams, char *pcParam[], char *pcValue[]);
+
+/**
+ * @brief Initialize the CGI handlers
+ * @param ConnectCallback The callback function to handle the connection request
+*/
+void CGIInit(const char* (*ConnectCallback)(int, int, char*[], char*[]));
+
+#endif // WEB_HANDLERS_CGI_H

--- a/WebHandlers/CMakeLists.txt
+++ b/WebHandlers/CMakeLists.txt
@@ -1,0 +1,17 @@
+add_library(web_handlers STATIC
+    CGI.cpp
+    CGI.h
+    SSI.cpp
+    SSI.h
+)
+
+target_include_directories(web_handlers PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(web_handlers
+    wifi_scanner
+    pico_stdlib
+    pico_cyw43_arch_lwip_poll
+    pico_lwip_http
+)

--- a/WebHandlers/SSI.cpp
+++ b/WebHandlers/SSI.cpp
@@ -1,0 +1,31 @@
+#include "SSI.h"
+
+u16_t SSIHandler(int iIndex, char *pcInsert, int iInsertLen)
+{
+    printf("SSIHandler called\n");
+    size_t printed = 0;
+    switch (iIndex) 
+    {
+        case 0:
+        {
+            std::string network_list;
+            for (const auto& network : GetWiFiNetworks()) 
+            {
+                network_list += "<option value=\"" + network + "\">" + network + "</option>";
+            }
+            size_t copied = std::min(network_list.length(), static_cast<size_t>(iInsertLen - 1));
+            strncpy(pcInsert, network_list.c_str(), copied);
+            pcInsert[copied] = '\0';
+            return copied;
+        }
+    }
+
+    printf("SSIHandler end\n");
+
+    return (u16_t)printed;
+}
+
+void SSIInit() 
+{
+    http_set_ssi_handler(SSIHandler, kSSITags, LWIP_ARRAYSIZE(kSSITags));
+}

--- a/WebHandlers/SSI.h
+++ b/WebHandlers/SSI.h
@@ -1,0 +1,28 @@
+#ifndef WEB_HANDLERS_SSI_H
+#define WEB_HANDLERS_SSI_H
+
+/**
+ * @file SSI.h
+ * @brief Server Side Includes, used to resolve dynamic content in the server
+**/
+
+#include "CGI.h"
+
+// SSI tags
+static const char * kSSITags[] = {"wifi"};
+
+/**
+ * @brief SSI handler function
+ * @param iIndex The index of the SSI tag
+ * @param pcInsert The buffer to insert the content
+ * @param iInsertLen The length of the buffer
+ * @return The length of the inserted content
+*/
+u16_t SSIHandler(int iIndex, char *pcInsert, int iInsertLen);
+
+/**
+ * @brief Initialize the SSI handlers
+*/
+void SSIInit();
+
+#endif // WEB_HANDLERS_SSI_H

--- a/WifiScanner/CMakeLists.txt
+++ b/WifiScanner/CMakeLists.txt
@@ -1,0 +1,15 @@
+add_library(wifi_scanner STATIC
+    WiFiScanner.cpp
+    NetworkInfo.h
+    WiFiScanner.h
+)
+
+target_include_directories(wifi_scanner PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/../common
+)
+
+target_link_libraries(wifi_scanner
+    pico_stdlib
+    pico_cyw43_arch_lwip_poll
+)

--- a/WifiScanner/NetworkInfo.h
+++ b/WifiScanner/NetworkInfo.h
@@ -1,0 +1,38 @@
+#ifndef WIFISCANNER_NETWORK_INFO
+#define WIFISCANNER_NETWORK_INFO
+
+/**
+ * @file NetworkInfo.h
+ * @brief The information about a scanned network
+**/
+
+#include <string>
+#include <cstdint>
+
+struct NetworkInfo 
+{
+    // the name of the network
+    std::string ssid;
+    // Received Signal Strength Indicator
+    int rssi = 0;
+    // channel of the wifi network
+    int channel = 0;
+    // the mac (or bssid) of the wifi network
+    std::string mac;
+    //authentication mode
+    uint8_t auth_mode = 0;
+
+    //overload the equal operator
+    bool operator=(const NetworkInfo & ntw_info) const
+    {
+        return ntw_info.ssid == ssid;
+    }
+
+    //overload the < (less than) operator
+    bool operator<(const NetworkInfo & ntw_info) const
+    {
+        return ssid < ntw_info.ssid;
+    }
+};
+
+#endif // WIFISCANNER_NETWORK_INFO

--- a/WifiScanner/WiFiScanner.cpp
+++ b/WifiScanner/WiFiScanner.cpp
@@ -1,0 +1,96 @@
+#include "WiFiScanner.h"
+
+WiFiScanner::WiFiScanner()
+{
+}
+
+WiFiScanner::~WiFiScanner()
+{
+}
+
+std::set<NetworkInfo> WiFiScanner::ScanNetworks()
+{
+    scanned_networks_.clear();
+
+    //start time of the scan operation
+    uint32_t start_time = to_ms_since_boot(get_absolute_time());
+    
+    bool scan_in_progress = false;
+    while(true) 
+    {
+        uint32_t current_time = to_ms_since_boot(get_absolute_time());
+        if((current_time - start_time) < connection_timeout_)  
+        {
+            if (!scan_in_progress) 
+            {
+                cyw43_wifi_scan_options_t scan_options = {0};
+                int err = cyw43_wifi_scan(&cyw43_state, &scan_options, this, ScanResult);
+                if (err == 0)
+                {
+                    //scan is in progress
+                    printf("WiFiScanner::ScanNetworks: Performing wifi scan\n");
+                    scan_in_progress = true;
+                }
+                else 
+                {
+                    //scan fails
+                    printf("WiFiScanner::ScanNetworks: Failed to start scan: %d\n", err);
+                }
+            } 
+            else if (!cyw43_wifi_scan_active(&cyw43_state)) 
+            {
+                printf("WiFiScanner::ScanNetworks: scan finished\n");
+                break;
+            }
+        }
+        else
+        {
+            printf("WiFiScanner::ScanNetworks: timeout reached\n");
+            break;
+        }
+        // if you are using pico_cyw43_arch_poll, then you must poll periodically from your
+        // main loop (not from a timer) to check for Wi-Fi driver or lwIP work that needs to be done.
+        cyw43_arch_poll();
+    }
+
+    finished_ = true;
+
+    return scanned_networks_;
+}
+
+int WiFiScanner::ScanResult(void* env, const cyw43_ev_scan_result_t* result)
+{
+    auto* scanner = static_cast<WiFiScanner*>(env);
+    if (result) 
+    {
+        printf("ssid: %-32s rssi: %4d chan: %3d mac: %02x:%02x:%02x:%02x:%02x:%02x sec: %u\n",
+            result->ssid, result->rssi, result->channel,
+            result->bssid[0], result->bssid[1], result->bssid[2], result->bssid[3], result->bssid[4], result->bssid[5],
+            result->auth_mode);
+        NetworkInfo ntw_info;
+        ntw_info.ssid = std::string(reinterpret_cast<const char*>(result->ssid), result->ssid_len);
+        ntw_info.rssi = result->rssi;
+        ntw_info.channel = result->channel;
+        ntw_info.mac = std::string(reinterpret_cast<const char*>(result->bssid), sizeof(result->bssid));
+        ntw_info.auth_mode = result->auth_mode;
+
+        if(scanner != nullptr)
+        {
+            if(!scanner->finished_)
+            {
+                scanner->scanned_networks_.insert(ntw_info);
+                printf("Added network with ssid:%s \n", ntw_info.ssid.c_str());
+            }
+            else
+            {
+                printf("Scanner already finished\n");
+            }
+        }
+        else
+        {
+            printf("Scanner is nullptr\n");
+        }
+    }
+
+    return 0;
+}

--- a/WifiScanner/WiFiScanner.h
+++ b/WifiScanner/WiFiScanner.h
@@ -1,0 +1,40 @@
+#ifndef WIFISCANNER_WIFI_SCANNER
+#define WIFISCANNER_WIFI_SCANNER
+
+/**
+ * @file WiFiScanner.h
+ * @brief Class to scan and return the available wifi networks
+**/
+
+#include <set>
+#include "NetworkInfo.h"
+#include "pico/stdlib.h"
+#include "pico/cyw43_arch.h"
+
+class WiFiScanner 
+{
+public:
+
+    WiFiScanner();
+
+    ~WiFiScanner();
+
+    /**
+     * Search for available wifi networks
+    */
+    std::set<NetworkInfo> ScanNetworks();
+
+private:
+    //connection timeout is 10s
+    uint32_t connection_timeout_ = 10000;
+
+    bool finished_ = false;
+
+    std::set<NetworkInfo> scanned_networks_;
+
+    /**
+     * static callback to get the result of the scan
+    */
+    static int ScanResult(void* env, const cyw43_ev_scan_result_t* result);
+};
+#endif // WIFISCANNER_WIFI_SCANNER

--- a/common/lwipopts.h
+++ b/common/lwipopts.h
@@ -1,0 +1,96 @@
+#ifndef __LWIPOPTS_H__
+#define __LWIPOPTS_H__
+
+// Common settings used in most of the pico_w examples
+// (see https://www.nongnu.org/lwip/2_1_x/group__lwip__opts.html for details)
+
+// allow override in some examples
+#ifndef NO_SYS
+#define NO_SYS                      1
+#endif
+// allow override in some examples
+#ifndef LWIP_SOCKET
+#define LWIP_SOCKET                 0
+#endif
+#if PICO_CYW43_ARCH_POLL
+#define MEM_LIBC_MALLOC             1
+#else
+// MEM_LIBC_MALLOC is incompatible with non polling versions
+#define MEM_LIBC_MALLOC             0
+#endif
+#define MEM_ALIGNMENT               4
+#define MEM_SIZE                    16384
+#define MEMP_NUM_TCP_SEG            32
+#define MEMP_NUM_ARP_QUEUE          10
+#define PBUF_POOL_SIZE              24
+#define LWIP_ARP                    1
+#define LWIP_ETHERNET               1
+#define LWIP_ICMP                   1
+#define LWIP_RAW                    1
+#define TCP_WND                     (8 * TCP_MSS)
+#define TCP_MSS                     1460
+#define TCP_SND_BUF                 (8 * TCP_MSS)
+#define TCP_SND_QUEUELEN            ((4 * (TCP_SND_BUF) + (TCP_MSS - 1)) / (TCP_MSS))
+#define LWIP_NETIF_STATUS_CALLBACK  1
+#define LWIP_NETIF_LINK_CALLBACK    1
+#define LWIP_NETIF_HOSTNAME         1
+#define LWIP_NETCONN                0
+#define MEM_STATS                   0
+#define SYS_STATS                   0
+#define MEMP_STATS                  0
+#define LINK_STATS                  0
+// #define ETH_PAD_SIZE                2
+#define LWIP_CHKSUM_ALGORITHM       3
+#define LWIP_DHCP                   1
+#define LWIP_IPV4                   1
+#define LWIP_TCP                    1
+#define LWIP_UDP                    1
+#define LWIP_DNS                    1
+#define LWIP_TCP_KEEPALIVE          1
+#define LWIP_NETIF_TX_SINGLE_PBUF   1
+#define DHCP_DOES_ARP_CHECK         0
+#define LWIP_DHCP_DOES_ACD_CHECK    0
+
+#ifndef NDEBUG
+#define LWIP_DEBUG                  1
+#define LWIP_STATS                  1
+#define LWIP_STATS_DISPLAY          1
+#endif
+
+#define LWIP_HTTPD 1
+#define LWIP_HTTPD_SSI 1
+#define LWIP_HTTPD_CGI 1
+#define LWIP_HTTPD_MAX_TAG_INSERT_LEN 2048
+// use generated fsdata
+#define HTTPD_FSDATA_FILE "../fsdata.c"
+
+#define ETHARP_DEBUG                LWIP_DBG_OFF
+#define NETIF_DEBUG                 LWIP_DBG_OFF
+#define PBUF_DEBUG                  LWIP_DBG_OFF
+#define API_LIB_DEBUG               LWIP_DBG_OFF
+#define API_MSG_DEBUG               LWIP_DBG_OFF
+#define SOCKETS_DEBUG               LWIP_DBG_OFF
+#define ICMP_DEBUG                  LWIP_DBG_OFF
+#define INET_DEBUG                  LWIP_DBG_OFF
+#define IP_DEBUG                    LWIP_DBG_OFF
+#define IP_REASS_DEBUG              LWIP_DBG_OFF
+#define RAW_DEBUG                   LWIP_DBG_OFF
+#define MEM_DEBUG                   LWIP_DBG_OFF
+#define MEMP_DEBUG                  LWIP_DBG_OFF
+#define SYS_DEBUG                   LWIP_DBG_OFF
+#define TCP_DEBUG                   LWIP_DBG_OFF
+#define TCP_INPUT_DEBUG             LWIP_DBG_OFF
+#define TCP_OUTPUT_DEBUG            LWIP_DBG_OFF
+#define TCP_RTO_DEBUG               LWIP_DBG_OFF
+#define TCP_CWND_DEBUG              LWIP_DBG_OFF
+#define TCP_WND_DEBUG               LWIP_DBG_OFF
+#define TCP_FR_DEBUG                LWIP_DBG_OFF
+#define TCP_QLEN_DEBUG              LWIP_DBG_OFF
+#define TCP_RST_DEBUG               LWIP_DBG_OFF
+#define UDP_DEBUG                   LWIP_DBG_OFF
+#define TCPIP_DEBUG                 LWIP_DBG_OFF
+#define PPP_DEBUG                   LWIP_DBG_OFF
+#define SLIP_DEBUG                  LWIP_DBG_OFF
+#define DHCP_DEBUG                  LWIP_DBG_OFF
+
+#endif /* __LWIPOPTS_H__ */

--- a/fs/error.json
+++ b/fs/error.json
@@ -1,0 +1,3 @@
+{
+    "success": false
+}

--- a/fs/index.shtml
+++ b/fs/index.shtml
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>WiFi Connection Setup</title>
+    <style>
+        /* Message box styles */
+        .message {
+            padding: 15px;
+            background-color: #7798d6;
+            color: rgb(0, 0, 0);
+            margin-bottom: 15px;
+            border-radius: 5px;
+            text-align: center;
+            font-size: 16px;
+            width: fit-content;
+            display: none; /* Hidden by default */
+        }
+    </style>
+</head>
+<body>
+    <h1>WiFi Connection Setup</h1>
+
+    <div id="messageBox" class="message"></div>
+
+    <form id="wifiForm" onsubmit="submitForm(event)">
+        <label for="ssid">Select WiFi Network:</label>
+        <select id="ssid" name="ssid" required>
+            <!--#wifi-->
+        </select>
+        <button type="button" id="scanButton" onclick="refreshWifiList()">Scan Networks</button>
+        <br><br>
+        <label for="password">Password:</label>
+        <input type="password" id="password" name="password">
+        <br><br>
+        <input type="submit" value="Connect" id="connectButton">
+    </form>
+    
+    <script>
+        function showMessage(message) {
+            const messageBox = document.getElementById('messageBox');
+            messageBox.textContent = message;
+            messageBox.style.display = 'block';
+        }
+
+        function hideMessage() {
+            const messageBox = document.getElementById('messageBox');
+            messageBox.style.display = 'none';
+        }
+
+        function showButton(id) {
+            const button = document.getElementById(id);
+            // To enable the button
+            button.disabled = false;
+            button.classList.remove('grayed-out');
+        }
+
+        function grayOutButton(id) {
+            const button = document.getElementById(id);
+            // To gray out the button
+            button.disabled = true;
+            button.classList.add('grayed-out');
+        }
+
+        function fetchWithTimeout(url, options, timeout = 10000) {
+            return new Promise((resolve, reject) => {
+                const controller = new AbortController();
+                const signal = controller.signal;
+                options.signal = signal;
+
+                const timeoutId = setTimeout(() => {
+                    controller.abort();
+                    reject(new Error('Request timed out'));
+                }, timeout);
+
+                fetch(url, options)
+                    .then(response => {
+                        clearTimeout(timeoutId);
+                        resolve(response);
+                    })
+                    .catch(error => {
+                        clearTimeout(timeoutId);
+                        reject(error);
+                    });
+            });
+        }
+
+        function refreshWifiList() {
+            showMessage("Scanning networks...");
+            grayOutButton('connectButton');
+            grayOutButton('scanButton');
+            fetchWithTimeout('/scan_wifi', {}, 10000)
+                .then(response => response.text())
+                .then(data => {
+                    document.querySelector('select[name="ssid"]').innerHTML = data;
+                    hideMessage();
+                    showButton('connectButton');
+                    showButton('scanButton');
+                })
+                .catch(error => {
+                    console.error('Error refreshing Wi-Fi list:', error);
+                    alert('Failed to refresh Wi-Fi list. Please try again.');
+                    hideMessage();
+                    showButton('connectButton');
+                    showButton('scanButton');
+                });
+        }
+
+        function submitForm(event) {
+            event.preventDefault();
+
+            showMessage("Trying to connect to wifi...");
+            grayOutButton('connectButton');
+            grayOutButton('scanButton');
+
+            const form = document.getElementById('wifiForm');
+            const formData = new FormData(form);
+
+            // Encode the password
+            const password = formData.get('password');
+            formData.set('password', encodeURIComponent(password));
+
+            const queryString = new URLSearchParams(formData).toString();
+
+            fetchWithTimeout('/connect?' + queryString, { method: 'GET' }, 20000)
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    alert("Wi-Fi connected successfully! Disabling AP mode.");
+                    showConnectedPage();
+                } else {
+                    throw new Error('Failed to connect to Wi-Fi');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('Failed to connect to Wi-Fi');
+                hideMessage();
+                showButton('connectButton');
+                showButton('scanButton');
+            });
+        }
+
+        // new content for the web page once connection is successful
+        function showConnectedPage() {
+            // Clear the current page content
+            document.body.innerHTML = '';
+
+            // Create and append new content
+            const newContent = document.createElement('div');
+            newContent.innerHTML = `
+                <h1>You are now connected to internet</h1>
+                <p>Your device has successfully connected to the Wi-Fi network. The Pico's network will be turned off.</p>
+            `;
+            document.body.appendChild(newContent);
+        }
+    </script>
+</body>
+</html>

--- a/fs/success.json
+++ b/fs/success.json
@@ -1,0 +1,3 @@
+{
+    "success": true
+}

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,169 @@
+#include "lwip/tcp.h"
+#include "lwip/ip4_addr.h"
+#include <sstream>
+#include <cctype>
+
+#include "lwip/apps/fs.h"
+
+#include "CGI.h"
+#include "SSI.h"
+
+char * ssid = NULL;
+char * password = NULL;
+
+bool wifi_connected = false;
+
+bool ConnectToWifi(const char * userSsid, const char * userPassword)
+{
+    printf("Connecting to Wi-Fi...\n");
+    if (cyw43_arch_wifi_connect_timeout_ms(userSsid, userPassword, CYW43_AUTH_WPA2_AES_PSK, 10000)) 
+    {
+        printf("Failed to connect to Wi-Fi\n");
+        return false;
+    }
+    printf("Connected to Wi-Fi\n");
+    return true;
+}
+
+const char* ConnectWiFiCGIHandler(int iIndex, int iNumParams, char *pcParam[], char *pcValue[]) 
+{   
+    if(operation_in_progress)
+    {
+        printf("Operation in progress\n");
+        return "/index.shtml";
+    }
+
+    operation_in_progress = true;
+    printf("WiFi Connection Request:\n");
+
+    char * userSsid = NULL;
+    char * userPassword = NULL;
+
+    for (int i = 0; i < iNumParams; i++) 
+    {
+        if (strcmp(pcParam[i], "ssid") == 0) 
+        {
+            userSsid = UrlDecode(pcValue[i]);
+        } 
+        else if (strcmp(pcParam[i], "password") == 0) 
+        {
+            userPassword = UrlDecode(pcValue[i]);
+        }
+    }
+
+    const char* returnPage = "/error.json";
+    
+    if (userSsid && userPassword) 
+    {
+        cyw43_arch_enable_sta_mode();
+        printf("Attempting to connect to SSID: %s, %s\n", userSsid, userPassword);
+
+        bool connected = ConnectToWifi(userSsid, userPassword);
+        cyw43_wifi_leave(&cyw43_state, CYW43_ITF_STA);
+
+        if(connected)
+        {
+            printf("Connection successful\n");
+            returnPage = "/success.json";
+            wifi_connected = true;
+
+            ssid = (char*)malloc(strlen(userSsid) + 1);
+            strcpy(ssid, userSsid);
+            password = (char*)malloc(strlen(userPassword) + 1);
+            strcpy(password, userPassword);
+        }
+    } 
+    else
+    {
+        printf("Invalid parameters\n");
+    } 
+
+    if(userSsid)
+    {
+        free(userSsid);
+    }
+    if(userPassword)
+    {
+        free(userPassword);
+    }
+
+    printf("returnPage is %s\n", returnPage);
+    operation_in_progress = false;
+
+    return returnPage;
+}
+
+int main() 
+{
+    stdio_init_all();
+    // Wait for serial console to connect
+    sleep_ms(3000); 
+
+    printf("RPI PICO W AP DEMO\n");
+
+    // Initialize CYW43 driver
+    if (cyw43_arch_init()) 
+    {
+        printf("Failed to initialize CYW43 driver\n");
+        return 1;
+    }
+
+    // Set up access point
+    cyw43_arch_enable_ap_mode(WIFI_SSID, WIFI_PASSWORD, CYW43_AUTH_WPA2_AES_PSK);
+    bool ap_mode_enabled = true; 
+    // Print AP info
+    printf("Access Point active. SSID: %s, Password: %s\n", WIFI_SSID, WIFI_PASSWORD);
+
+    httpd_init();
+    SSIInit();
+    CGIInit(ConnectWiFiCGIHandler);
+
+    // Set new IP configuration
+    ip4_addr_t ip, netmask, gateway;
+    IP4_ADDR(&ip, 192, 168, 1, 1);
+    IP4_ADDR(&netmask, 255, 255, 255, 0);
+    IP4_ADDR(&gateway, 192, 168, 1, 1);
+
+    // Apply the new configuration
+    netif_set_addr(netif_default, &ip, &netmask, &gateway);
+
+    // Main loop
+    while(1)
+    {
+        // Handle any pending network events
+        cyw43_arch_poll();
+        sleep_ms(10);
+        if(wifi_connected)
+        {
+            if(ap_mode_enabled)
+            {
+                int i = 0;
+                while(i < 100)
+                {
+                    cyw43_arch_poll();
+                    sleep_ms(100);
+                    i++;
+                }
+                printf("disabling ap mode\n");
+                cyw43_arch_disable_ap_mode();
+                ap_mode_enabled = false;
+                ConnectToWifi(ssid, password);
+            }
+        }
+    }
+
+    printf("End of program\n");
+
+    cyw43_arch_deinit();
+
+    if(ssid)
+    {   
+        free(ssid);
+    }
+    if(password)
+    {
+        free(password);
+    }
+
+    return 0;
+}

--- a/pico_sdk_import.cmake
+++ b/pico_sdk_import.cmake
@@ -1,0 +1,84 @@
+# This is a copy of <PICO_SDK_PATH>/external/pico_sdk_import.cmake
+
+# This can be dropped into an external project to help locate this SDK
+# It should be include()ed prior to project()
+
+if (DEFINED ENV{PICO_SDK_PATH} AND (NOT PICO_SDK_PATH))
+    set(PICO_SDK_PATH $ENV{PICO_SDK_PATH})
+    message("Using PICO_SDK_PATH from environment ('${PICO_SDK_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT} AND (NOT PICO_SDK_FETCH_FROM_GIT))
+    set(PICO_SDK_FETCH_FROM_GIT $ENV{PICO_SDK_FETCH_FROM_GIT})
+    message("Using PICO_SDK_FETCH_FROM_GIT from environment ('${PICO_SDK_FETCH_FROM_GIT}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_PATH} AND (NOT PICO_SDK_FETCH_FROM_GIT_PATH))
+    set(PICO_SDK_FETCH_FROM_GIT_PATH $ENV{PICO_SDK_FETCH_FROM_GIT_PATH})
+    message("Using PICO_SDK_FETCH_FROM_GIT_PATH from environment ('${PICO_SDK_FETCH_FROM_GIT_PATH}')")
+endif ()
+
+if (DEFINED ENV{PICO_SDK_FETCH_FROM_GIT_TAG} AND (NOT PICO_SDK_FETCH_FROM_GIT_TAG))
+    set(PICO_SDK_FETCH_FROM_GIT_TAG $ENV{PICO_SDK_FETCH_FROM_GIT_TAG})
+    message("Using PICO_SDK_FETCH_FROM_GIT_TAG from environment ('${PICO_SDK_FETCH_FROM_GIT_TAG}')")
+endif ()
+
+if (PICO_SDK_FETCH_FROM_GIT AND NOT PICO_SDK_FETCH_FROM_GIT_TAG)
+  set(PICO_SDK_FETCH_FROM_GIT_TAG "master")
+  message("Using master as default value for PICO_SDK_FETCH_FROM_GIT_TAG")
+endif()
+
+set(PICO_SDK_PATH "${PICO_SDK_PATH}" CACHE PATH "Path to the Raspberry Pi Pico SDK")
+set(PICO_SDK_FETCH_FROM_GIT "${PICO_SDK_FETCH_FROM_GIT}" CACHE BOOL "Set to ON to fetch copy of SDK from git if not otherwise locatable")
+set(PICO_SDK_FETCH_FROM_GIT_PATH "${PICO_SDK_FETCH_FROM_GIT_PATH}" CACHE FILEPATH "location to download SDK")
+set(PICO_SDK_FETCH_FROM_GIT_TAG "${PICO_SDK_FETCH_FROM_GIT_TAG}" CACHE FILEPATH "release tag for SDK")
+
+if (NOT PICO_SDK_PATH)
+    if (PICO_SDK_FETCH_FROM_GIT)
+        include(FetchContent)
+        set(FETCHCONTENT_BASE_DIR_SAVE ${FETCHCONTENT_BASE_DIR})
+        if (PICO_SDK_FETCH_FROM_GIT_PATH)
+            get_filename_component(FETCHCONTENT_BASE_DIR "${PICO_SDK_FETCH_FROM_GIT_PATH}" REALPATH BASE_DIR "${CMAKE_SOURCE_DIR}")
+        endif ()
+        # GIT_SUBMODULES_RECURSE was added in 3.17
+        if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.17.0")
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+                    GIT_SUBMODULES_RECURSE FALSE
+            )
+        else ()
+            FetchContent_Declare(
+                    pico_sdk
+                    GIT_REPOSITORY https://github.com/raspberrypi/pico-sdk
+                    GIT_TAG ${PICO_SDK_FETCH_FROM_GIT_TAG}
+            )
+        endif ()
+
+        if (NOT pico_sdk)
+            message("Downloading Raspberry Pi Pico SDK")
+            FetchContent_Populate(pico_sdk)
+            set(PICO_SDK_PATH ${pico_sdk_SOURCE_DIR})
+        endif ()
+        set(FETCHCONTENT_BASE_DIR ${FETCHCONTENT_BASE_DIR_SAVE})
+    else ()
+        message(FATAL_ERROR
+                "SDK location was not specified. Please set PICO_SDK_PATH or set PICO_SDK_FETCH_FROM_GIT to on to fetch from git."
+                )
+    endif ()
+endif ()
+
+get_filename_component(PICO_SDK_PATH "${PICO_SDK_PATH}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+if (NOT EXISTS ${PICO_SDK_PATH})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' not found")
+endif ()
+
+set(PICO_SDK_INIT_CMAKE_FILE ${PICO_SDK_PATH}/pico_sdk_init.cmake)
+if (NOT EXISTS ${PICO_SDK_INIT_CMAKE_FILE})
+    message(FATAL_ERROR "Directory '${PICO_SDK_PATH}' does not appear to contain the Raspberry Pi Pico SDK")
+endif ()
+
+set(PICO_SDK_PATH ${PICO_SDK_PATH} CACHE PATH "Path to the Raspberry Pi Pico SDK" FORCE)
+
+include(${PICO_SDK_INIT_CMAKE_FILE})


### PR DESCRIPTION
It is an example of how we can connect our RPI Pico W to a custom WiFi network.
This example does:

1. Configure the RPI Pico W as an AP.
2. Setup the index.shtml web page and the default gateway ip as 192.168.1.1
3. Register the functions to scan wifi networks and to check SSID and password to connect to a wifi network.
4. If connection is successful, switch from AP mode to STA mode and keep the RPI Pico W connected to the WiFi network.

It allows us to connect to different WiFi networks without set manually in the code. 